### PR TITLE
[T5] (1) Add historical data service

### DIFF
--- a/src/main/java/com/ase/restservice/service/FinanceService.java
+++ b/src/main/java/com/ase/restservice/service/FinanceService.java
@@ -3,8 +3,10 @@ package com.ase.restservice.service;
 import com.ase.restservice.exception.InvalidStockIDException;
 import com.ase.restservice.model.Stock;
 import java.io.IOException;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import yahoofinance.histquotes.HistoricalQuote;
 import yahoofinance.YahooFinance;
 
 /**
@@ -73,6 +75,28 @@ public class FinanceService implements FinanceServiceI {
             Float apiPrice = getStockPrice(stockId);
             Stock stockObj = new Stock(stockId, apiPrice);
             return stockService.createStock(stockObj);
+        } catch (InvalidStockIDException e) {
+            throw new InvalidStockIDException(e);
+        } catch (IOException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Serve historical data from Yahoo! Finance API
+     *
+     * @param stockId Stock ID to get historical data of
+     * @return A list of historical quotes of the stock
+     * @throws InvalidStockIDException if the stock ID is invalid
+     * @throws IOException when there is a connection error
+     */
+    public List<HistoricalQuote> getHistorical(final String stockId)
+            throws InvalidStockIDException, IOException {
+        try {
+            Float apiPrice = getStockPrice(stockId); //dummy check for valid stock ID
+            yahoofinance.Stock apiStock = YahooFinance.get(stockId);
+            List<HistoricalQuote> histQuotes = apiStock.getHistory();
+            return histQuotes;
         } catch (InvalidStockIDException e) {
             throw new InvalidStockIDException(e);
         } catch (IOException e) {

--- a/src/main/java/com/ase/restservice/service/interface/FinanceServiceI.java
+++ b/src/main/java/com/ase/restservice/service/interface/FinanceServiceI.java
@@ -3,6 +3,8 @@ package com.ase.restservice.service;
 import com.ase.restservice.exception.InvalidStockIDException;
 import com.ase.restservice.model.Stock;
 import java.io.IOException;
+import java.util.List;
+import yahoofinance.histquotes.HistoricalQuote;
 
 /**
  * Interface for Finance service (involving Yahoo! Finance API)
@@ -35,4 +37,15 @@ public interface FinanceServiceI {
      * @throws IOException when there is a connection error
      */
     Stock createStockFromId(String stockId) throws InvalidStockIDException, IOException;
+
+    /**
+     * Serve historical data from Yahoo! Finance API
+     *
+     * @param stockId Stock ID to get historical data of
+     * @return A list of historical quotes of the stock
+     * @throws InvalidStockIDException if the stock ID is invalid
+     * @throws IOException when there is a connection error
+     */
+    List<HistoricalQuote> getHistorical(String stockId)
+        throws InvalidStockIDException, IOException;
 }


### PR DESCRIPTION
Adding the ability to serve historical data. 

_Right now we only show month-by-month, and we can change the granularity after having conversations about how the end-client might use this data._

Example endpoint: `http://localhost:8080/finance/GOOGL/historical`
Example response:
```json
[
  {
    "symbol": "GOOGL",
    "date": "2021-12-01T05:00:00.000+00:00",
    "open": 144,
    "low": 139.320999,
    "high": 149.100006,
    "close": 144.852005,
    "adjClose": 144.852005,
    "volume": 619694000
  },
  {
    "symbol": "GOOGL",
    "date": "2022-01-01T05:00:00.000+00:00",
    "open": 145.054993,
    "low": 124.5,
    "high": 146.485001,
    "close": 135.303497,
    "adjClose": 135.303497,
    "volume": 767206000
  },
  {
    "symbol": "GOOGL",
    "date": "2022-02-01T05:00:00.000+00:00",
    "open": 137.594498,
    "low": 124.953499,
    "high": 151.546494,
    "close": 135.057007,
    "adjClose": 135.057007,
    "volume": 928126000
  },
  {
    "symbol": "GOOGL",
    "date": "2022-03-01T05:00:00.000+00:00",
    "open": 134.878494,
    "low": 125.275002,
    "high": 143.793503,
    "close": 139.067505,
    "adjClose": 139.067505,
    "volume": 729162000
  },
  {
    "symbol": "GOOGL",
    "date": "2022-04-01T04:00:00.000+00:00",
    "open": 139.5,
    "low": 112.736504,
    "high": 143.712006,
    "close": 114.109497,
    "adjClose": 114.109497,
    "volume": 761152000
  },
  {
    "symbol": "GOOGL",
    "date": "2022-05-01T04:00:00.000+00:00",
    "open": 113.404999,
    "low": 101.884499,
    "high": 122.8545,
    "close": 113.762001,
    "adjClose": 113.762001,
    "volume": 850450000
  },
  {
    "symbol": "GOOGL",
    "date": "2022-06-01T04:00:00.000+00:00",
    "open": 114.855003,
    "low": 105.045998,
    "high": 119.347,
    "close": 108.962997,
    "adjClose": 108.962997,
    "volume": 770754000
  },
  {
    "symbol": "GOOGL",
    "date": "2022-07-01T04:00:00.000+00:00",
    "open": 107.932999,
    "low": 104.07,
    "high": 119.684998,
    "close": 116.32,
    "adjClose": 116.32,
    "volume": 789529700
  },
  {
    "symbol": "GOOGL",
    "date": "2022-08-01T04:00:00.000+00:00",
    "open": 115.300003,
    "low": 107.800003,
    "high": 122.43,
    "close": 108.220001,
    "adjClose": 108.220001,
    "volume": 515852700
  },
  {
    "symbol": "GOOGL",
    "date": "2022-09-01T04:00:00.000+00:00",
    "open": 108.279999,
    "low": 95.559998,
    "high": 111.620003,
    "close": 95.650002,
    "adjClose": 95.650002,
    "volume": 613278900
  },
  {
    "symbol": "GOOGL",
    "date": "2022-10-01T04:00:00.000+00:00",
    "open": 96.760002,
    "low": 91.800003,
    "high": 104.82,
    "close": 94.510002,
    "adjClose": 94.510002,
    "volume": 681488300
  },
  {
    "symbol": "GOOGL",
    "date": "2022-11-01T04:00:00.000+00:00",
    "open": 95.449997,
    "low": 83.339996,
    "high": 100.139999,
    "close": 97.459999,
    "adjClose": 97.459999,
    "volume": 626525200
  },
  {
    "symbol": "GOOGL",
    "date": "2022-11-25T05:00:00.000+00:00",
    "open": 98.239998,
    "low": 97.404999,
    "high": 98.639999,
    "close": 97.459999,
    "adjClose": 97.459999,
    "volume": 9701441
  }
]
```