### PR TITLE
transfer asset endpoint with new function in transaction service

### DIFF
--- a/src/main/java/com/ase/restservice/controller/TransferController.java
+++ b/src/main/java/com/ase/restservice/controller/TransferController.java
@@ -1,0 +1,31 @@
+package com.ase.restservice.controller;
+
+import com.ase.restservice.exception.AccountNotFoundException;
+import com.ase.restservice.exception.InvalidOrderTypeException;
+import com.ase.restservice.exception.InvalidTransactionException;
+import com.ase.restservice.exception.ResourceNotFoundException;
+import com.ase.restservice.model.Asset;
+import com.ase.restservice.model.Transaction;
+import com.ase.restservice.service.TransactionService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public final class TransferController {
+  @Autowired
+  private TransactionService transactionService;
+
+  @Operation(summary = "Transfer assets from sender to reciever")
+  @PostMapping("/transfer/{recipientId}")
+  public Optional<Asset> executeTransfer(@PathVariable final String recipientId, @RequestBody
+  final Transaction transaction)
+      throws AccountNotFoundException, ResourceNotFoundException,
+      InvalidOrderTypeException, InvalidTransactionException {
+    return transactionService.executeTransfer(transaction, recipientId);
+  }
+}


### PR DESCRIPTION
This allows for one user to send an amount of one of their assets to another user. How to do so:
- Send a SELL transaction type through the endpoint /transfer/{recipientId}, where recipientId is the accountId of the user who you are transfering to. 

Currently does not support only sending within the same client, did not seem necessary for demo purposes. 
Throws an SQL error if recipientId is not a valid account. 